### PR TITLE
fix: add function name to skip backup on permenant storage

### DIFF
--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -41,7 +41,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
     uploadResult = await sdk.storage().uploadPrivateFile({ filePath: bundledFilePath, onUploadProgress: uploadOnProgress(progressBar) });
   } else {
     const fileLikeObject = await getFileLikeObject(bundledFilePath);
-    uploadResult = await sdk.storage().uploadFile({ file: fileLikeObject, onUploadProgress: uploadOnProgress(progressBar) });
+    uploadResult = await sdk.storage().uploadFile({ file: fileLikeObject, options: { functionName: functionToDeploy.name }, onUploadProgress: uploadOnProgress(progressBar) });
   }
 
   if (!uploadResult.pin.cid) {


### PR DESCRIPTION
## Why?

skip backing up of fleek functions to permenant storage layer. this Pr only adds function name from cli. rest is done in sdk and upload proxy [PR](https://github.com/FleekHQ/fleek/pull/2954)

## How?

- pass function name when uploading to storage
- the upload proxy in the backend skips backing up when it finds out, the upload to storage is for function

## Tickets?

- [APP2-947](https://linear.app/fleekxyz/issue/APP2-947)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ NA] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ NA] You have provided tests

## Security checklist?

- [ NA] Sensitive data has been identified and is being protected properly
- [ NA] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
