### PR TITLE
fix: Add treeshaking to the bundler, more tweaks; Output file in .fleek folder;

### DIFF
--- a/src/commands/functions/utils/getCodeFromPath.ts
+++ b/src/commands/functions/utils/getCodeFromPath.ts
@@ -4,7 +4,6 @@ import { build, BuildOptions, Plugin } from 'esbuild';
 import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
 import { filesFromPaths } from 'files-from-path';
 import * as fs from 'fs';
-import os from 'os';
 
 import { output } from '../../../cli';
 import { t } from '../../../utils/translation';
@@ -75,7 +74,12 @@ const bundleCode = async (args: BundleCodeArgs) => {
     cliProgress.Presets.shades_grey
   );
 
-  const tempDir = os.tmpdir();
+  const tempDir = '.fleek';
+
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir);
+  }
+
   const outFile = tempDir + '/function.js';
   const unsupportedModulesUsed = new Set<string>();
 
@@ -115,8 +119,11 @@ const bundleCode = async (args: BundleCodeArgs) => {
     entryPoints: [filePath],
     bundle: true,
     logLevel: 'silent',
-    platform: 'neutral',
-    mainFields: ['module', 'main'],
+    platform: 'browser',
+    format: 'esm',
+    target: 'esnext',
+    treeShaking: true,
+    mainFields: ['browser', 'module', 'main'],
     external: [...Object.values(supportedModulesAliases)],
     alias: supportedModulesAliases,
     outfile: outFile,


### PR DESCRIPTION
## Why?

- Remove unnecessary code from the bundle.
- Less restrictive bundling.
- Target the browser for more Deno/v8 compatibility.
- Output file in the folder so we can more easily access the bundled/uploaded code.

## How?

- Tweaked esbuild configuration
- mkdir over tmpdir

## Tickets?

- [APP2-955](https://linear.app/fleekxyz/issue/APP2-955/investigate-user-issues-with-bundling)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
