### PR TITLE
fix: keep function target file when noBundle is set

### DIFF
--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -66,7 +66,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
     });
   }
 
-  if (!output.debugEnabled) {
+  if (!output.debugEnabled && !args.noBundle) {
     fs.rmSync(bundledFilePath);
   }
 


### PR DESCRIPTION
## Why?

We should only delete the file when it was created by us. If the user sets the --noBundle flag, we should not delete that file, as it wasn't created by the CLI.

## How?

- Check if the noBundle flag is set before deleting the file.

## Tickets?

- no ticket

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
