### PR TITLE
fix: return env vars to bundler

### DIFF
--- a/src/commands/functions/utils/getCodeFromPath.ts
+++ b/src/commands/functions/utils/getCodeFromPath.ts
@@ -3,7 +3,11 @@ import * as os from 'node:os';
 
 // TODO: These error messages should be revised
 // e.g. FleekFunctionPathNotValidError happens regardless of bundling
-import { FleekFunctionBundlingFailedError, FleekFunctionPathNotValidError, UnknownError } from '@fleek-platform/errors';
+import {
+  FleekFunctionBundlingFailedError,
+  FleekFunctionPathNotValidError,
+  UnknownError,
+} from '@fleek-platform/errors';
 import cliProgress from 'cli-progress';
 import { type BuildOptions, type Plugin, build } from 'esbuild';
 import { filesFromPaths } from 'files-from-path';
@@ -61,7 +65,7 @@ const transpileCode = async (args: TranspileCodeArgs) => {
         action: t(bundle ? 'bundlingCode' : 'transformingCode'),
       }),
     },
-    cliProgress.Presets.shades_grey
+    cliProgress.Presets.shades_grey,
   );
 
   let tempDir: string;
@@ -97,7 +101,7 @@ const transpileCode = async (args: TranspileCodeArgs) => {
       nodeProtocolImportSpecifier({
         // Handle the error gracefully
         onError: () => output.error(t('failedToApplyNodeImportProtocol')),
-      })
+      }),
     );
   }
 
@@ -129,7 +133,12 @@ globalThis.fleek={env:{${buildEnvVars({ env })}}};`,
     progressBar.stop();
 
     const errorMessage =
-      e && typeof e === 'object' && 'message' in e && typeof e.message === 'string' ? e.message : t('unknownTransformError');
+      e &&
+      typeof e === 'object' &&
+      'message' in e &&
+      typeof e.message === 'string'
+        ? e.message
+        : t('unknownTransformError');
 
     const transpileResponse: TranspileResponse = {
       path: filePath,
@@ -170,7 +179,11 @@ const checkUserSourceCodeSupport = async (filePath: string) => {
   return reRequireSyntax.test(contents);
 };
 
-export const getCodeFromPath = async (args: { filePath: string; bundle: boolean; env: EnvironmentVariables }) => {
+export const getCodeFromPath = async (args: {
+  filePath: string;
+  bundle: boolean;
+  env: EnvironmentVariables;
+}) => {
   const { filePath, bundle, env } = args;
 
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
## Why?

Return parsed env vars, the bundler header wasn't receiving them as the function wasn't returning.

## How?

- Add missing return statement

## Tickets?

- no ticket

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
