### PR TITLE
refactor: 💡 CI/CD Changeset Status check for CLI

### DIFF
--- a/.github/workflows/changeset-version-management.yml
+++ b/.github/workflows/changeset-version-management.yml
@@ -69,17 +69,15 @@ jobs:
           # Commit hash that triggered workflow
           commitHash="${{ github.sha }}"
 
-          diffTree=$(git diff-tree --no-commit-id --name-only -r "$commitHash")
+          pendingChangesetList=$(find .changeset -type f -name "*.md" ! -name "README.md")
 
-          if [[ -n "$diffTree" ]]; then
-            echo "⚠️ The diff command found:"
-            echo "$diffTree"
-          else
-            echo "⚠️ The diff result is empty!"
+          if [[ -n "$pendingChangesetList" ]]; then
+            echo "⚠️ There are pending changeset files:"
+            echo "$pendingChangesetList"
           fi
           
           # If no changes found, skip
-          if echo "$diffTree" | grep -qE "$changesetArtifactsRegex"; then
+          if echo "$pendingChangesetList" | grep -qE "$changesetArtifactsRegex"; then
             echo "✅ Changeset found!"
           else
             echo "⚠️ Warning: The .changeset directory doesn't have new changesets, should skip!"


### PR DESCRIPTION
## Why?

The CI/CD Changeset Status check, now gets the diff-tree recursively and match checks for a regex pattern of `.changeset/<filename>.md`. For some reason the current version is not working in CI/CD.

⚠️ Related to https://github.com/FleekHQ/fleek/pull/3216

- [PLAT-1396](https://linear.app/fleekxyz/issue/PLAT-1396/cicd-changeset-status-check-is-failing)

## How?

- Extend pattern match to match markdown extension
- Show diff status output

## Tickets?

- [PLAT-1396](https://linear.app/fleekxyz/issue/PLAT-1396/cicd-changeset-status-check-is-failing)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
