### PR TITLE
fix: 🐛 ipfs-http-client over SDK v3 missing pkg native-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash-es": "^4.17.21",
     "multiformats": "^9.9.0",
     "nanoid": "^3.3.4",
+    "native-fetch": "^4.0.2",
     "ora": "^3.4.0",
     "press-any-key": "^0.1.1",
     "prompts": "^2.4.2",


### PR DESCRIPTION
## Why?

ipfs-http-client over SDK v3 missing package

## How?

- Add dependency native-fetch

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
