### PR TITLE
fix: 🐛 Typescript configuration not recognized by sites deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/cli.js",
   "types": "./dist/cli.d.ts",
   "scripts": {
-    "build": "pnpm clean:dist && pnpm transpile && pnpm bundle && pnpm cp:polyfills",
+    "build": "pnpm clean:dist && pnpm transpile && pnpm bundle && pnpm cp:polyfills && cp -r ./src/templates ./dist",
     "build:ci": "pnpm run build",
     "bundle": "ts-node -r dotenv/config bundle.ts",
     "changeset:add": "pnpm exec changeset",

--- a/src/utils/configuration/saveConfiguration.ts
+++ b/src/utils/configuration/saveConfiguration.ts
@@ -24,12 +24,12 @@ type ConfigFilePath = string;
 
 const filePathForTypescriptConfig = path.join(
   __dirname,
-  '../../templates/sites/config',
+  './templates/sites/config',
   getConfigTemplateByTypeName('Typescript'),
 );
 const filePathForJavascriptConfig = path.join(
   __dirname,
-  '../../templates/sites/config',
+  './templates/sites/config',
   getConfigTemplateByTypeName('Javascript'),
 );
 


### PR DESCRIPTION
## Why?

Typescript configuration not recognized by sites deploy.

## How?

- Fix the relative path for the template files

## Tickets?

- [PLAT-1339](https://linear.app/fleekxyz/issue/PLAT-1339/%5Bcli%5D%5Bdeploy%5D-typescript-configuration-files-are-not-recognized-by)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

<img width="819" alt="Screenshot 2024-09-18 at 19 07 51" src="https://github.com/user-attachments/assets/27a3d071-6b7e-4b1f-903b-8f9962e7bdba">
