### PR TITLE
chore: 🤖 Add Help subcommand for functions subcommands

### DIFF
--- a/src/commands/functions/index.ts
+++ b/src/commands/functions/index.ts
@@ -30,7 +30,8 @@ export default (program: Command) => {
     .description(t('functionsCreateDescription'))
     .action((options: { name?: string }) =>
       createActionHandler({ name: options.name }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('delete')
@@ -38,7 +39,8 @@ export default (program: Command) => {
     .option('-n, --name <functionName>', t('functionName'))
     .action((options: { name?: string }) =>
       deleteActionHandler({ name: options.name }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('update')
@@ -60,7 +62,8 @@ export default (program: Command) => {
           slug: options.slug,
           status: options.status,
         }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('deploy')
@@ -85,12 +88,14 @@ export default (program: Command) => {
         envFile: options.envFile,
         sgx: options.sgx,
       }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('list')
     .description(t('listFunctionsDesc'))
-    .action(() => listActionHandler());
+    .action(() => listActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('deployments')
@@ -98,10 +103,12 @@ export default (program: Command) => {
     .description(t('deploymentsListForSelectedFunction'))
     .action((options: { name?: string }) =>
       listDeploymentsActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('help')
     .description(t('printHelp'))
-    .action(() => cmd.help());
+    .action(() => cmd.help())
+    .addHelpCommand();
 };


### PR DESCRIPTION
## Why?

The Functions subcommands should display detailed information to utilize any flags and options.

## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1509](https://linear.app/fleekxyz/issue/PLAT-1509/add-help-to-functions-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> Update

<img width="810" alt="Screenshot 2024-09-19 at 16 12 56" src="https://github.com/user-attachments/assets/e2fba05e-b47d-4412-be4d-2a186a0e1f5a">

> Deploy

<img width="813" alt="Screenshot 2024-09-19 at 16 13 25" src="https://github.com/user-attachments/assets/c8b316c6-07a4-41e4-b5c7-6e63a83867a3">
