### PR TITLE
chore: 🤖 Add Help subcommand for applications subcommands

### DIFF
--- a/src/commands/applications/index.ts
+++ b/src/commands/applications/index.ts
@@ -45,7 +45,7 @@ export default (program: Command) => {
         updateApplicationActionHandler(options),
     )
     .addHelpCommand();
-    
+
   cmd
     .command('delete')
     .description(t('deleteAppClient'))


### PR DESCRIPTION
## Why?

The Applications subcommands should display detailed information to utilize any flags and options.


## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1510](https://linear.app/fleekxyz/issue/PLAT-1510/add-help-to-applications-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> List

<img width="807" alt="Screenshot 2024-09-19 at 16 20 33" src="https://github.com/user-attachments/assets/2ed2e191-56a0-4a72-ac52-55001d87db27">

> Create

<img width="813" alt="Screenshot 2024-09-19 at 16 21 00" src="https://github.com/user-attachments/assets/b942bdfe-1344-4696-8201-878add1bce8b">
