### PR TITLE
chore: 🤖 Add Help subcommand for auth subcommands #36

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -349,5 +349,6 @@
   "failedCalculateBlake3Hash": "Failed to calculate the Blake3 hash. Please try again!",
   "failedDeployFleekFunction": "Failed to deploy the Fleek Function. Please try again!",
   "warnProvideValidDomainName": "Please provide a valid domain name.",
-  "cmdAuthLoginDescription": "Authenticate the CLI session using the Fleek Platform Web app. Open the URL in your favourite browser to initiate the browser-based login process. Select your preferred authentication method and return to CLI once completed."
+  "cmdAuthLoginDescription": "Authenticate the CLI session using the Fleek Platform Web app. Open the URL in your favourite browser to initiate the browser-based login process. Select your preferred authentication method and return to CLI once completed.",
+  "cmdAuthLogoutDescription": "Ends your active CLI session, securing your account. Disables access to personal features such as storage and site deployment until re-authentication."
 }

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -27,7 +27,7 @@ export default (cmd: Command) => {
 
   cmd
     .command('logout')
-    .description(t('loginToFlkPlt', { status: t('logoutOf') }))
+    .description(t('cmdAuthLogoutDescription'))
     .action(logoutActionHandler)
     .addHelpCommand();
 };


### PR DESCRIPTION
## Why?

The Auth subcommands should display detailed information to utilize any flags and options.

## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1511](https://linear.app/fleekxyz/issue/PLAT-1511/add-help-to-auth-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> Login

<img width="812" alt="Screenshot 2024-09-19 at 16 37 24" src="https://github.com/user-attachments/assets/92e2ea55-b754-476c-a1cc-32fba80788d9">

> Logout

<img width="812" alt="Screenshot 2024-09-19 at 16 37 01" src="https://github.com/user-attachments/assets/6919387c-c696-4320-a3e3-8581e527d560">
