### PR TITLE
chore: 🤖 Add Help subcommand for domains subcommands

### DIFF
--- a/src/commands/domains/index.ts
+++ b/src/commands/domains/index.ts
@@ -18,9 +18,7 @@ export default (program: Command) => {
     .command('list')
     .option('--siteId <string>', t('siteIDDomainAssignTo'))
     .description(t('listAllDomainsSelectProject'))
-    .action((options: { siteId?: string }) =>
-      listDomainsActionHandler(options),
-    )
+    .action((options: { siteId?: string }) => listDomainsActionHandler(options))
     .addHelpCommand();
 
   cmd


### PR DESCRIPTION
## Why?

The Auth subcommands should display detailed information to utilize any flags and options.

## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1512](https://linear.app/fleekxyz/issue/PLAT-1512/add-help-to-domains-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> list

<img width="808" alt="Screenshot 2024-09-19 at 16 41 41" src="https://github.com/user-attachments/assets/823c3dd9-c30a-4aae-91bc-7882cd3f25e4">

> detail

<img width="812" alt="Screenshot 2024-09-19 at 16 41 58" src="https://github.com/user-attachments/assets/9cbb3ccc-782e-4e19-8895-2c4df8c84dee">

