### PR TITLE
chore: 🤖 Add Help subcommand for ens subcommands #38

### DIFF
--- a/src/commands/ens/index.ts
+++ b/src/commands/ens/index.ts
@@ -13,7 +13,7 @@ export default (program: Command) => {
     .option('-h, --help', t('printHelp'))
     .description(t('ensCmdDescription'))
     .addHelpCommand();
-    
+
   cmd
     .command('create')
     .option('--siteId <string>', t('siteIdOf'))


### PR DESCRIPTION
## Why?

The Ens subcommands should display detailed information to utilize any flags and options.

## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1513](https://linear.app/fleekxyz/issue/PLAT-1513/add-help-to-ens-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> delete

<img width="809" alt="Screenshot 2024-09-19 at 16 45 30" src="https://github.com/user-attachments/assets/b75acdd7-019a-44b2-9895-8fed4b34bfb7">

> detail

<img width="808" alt="Screenshot 2024-09-19 at 16 45 51" src="https://github.com/user-attachments/assets/a5058fe5-a58d-4822-8392-4a22fad25e66">
