### PR TITLE
chore: 🤖 Add Help subcommand for gateways subcommands

### DIFF
--- a/src/commands/gateways/index.ts
+++ b/src/commands/gateways/index.ts
@@ -48,7 +48,7 @@ export default (program: Command) => {
       createPrivateGatewayActionHandler(options),
     )
     .addHelpCommand();
-    
+
   cmd
     .command('delete')
     .option(

--- a/src/commands/gateways/index.ts
+++ b/src/commands/gateways/index.ts
@@ -15,7 +15,8 @@ export default (program: Command) => {
   cmd
     .command('list')
     .description(t('listAllPrvGwForSelectProject'))
-    .action(() => listPrivateGatewaysActionHandler());
+    .action(() => listPrivateGatewaysActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('detail')
@@ -36,7 +37,8 @@ export default (program: Command) => {
     .description(t('gatewayShowDetails'))
     .action((options: { id?: string; slug?: string }) =>
       detailPrivateGatewayActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('create')
@@ -44,8 +46,9 @@ export default (program: Command) => {
     .description(t('gatewayCreateCmdDesc'))
     .action((options: { name?: string }) =>
       createPrivateGatewayActionHandler(options),
-    );
-
+    )
+    .addHelpCommand();
+    
   cmd
     .command('delete')
     .option(
@@ -67,7 +70,8 @@ export default (program: Command) => {
     .description(t('gatewayDelete'))
     .action((options: { id?: string; slug?: string }) =>
       deletePrivateGatewayActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd.command('help').description(t('printHelp'));
 };


### PR DESCRIPTION
## Why?

The Gateways subcommands should display detailed information to utilize any flags and options.

## How?

- Declare each subcommand to include the help command

## Tickets?

- [PLAT-1514](https://linear.app/fleekxyz/issue/PLAT-1514/add-help-to-gateways-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> Detail

<img width="812" alt="Screenshot 2024-09-19 at 16 49 32" src="https://github.com/user-attachments/assets/18d454ab-b163-4cee-a295-e0c2de16148d">

> Create

<img width="806" alt="Screenshot 2024-09-19 at 16 50 05" src="https://github.com/user-attachments/assets/ef3bc680-7124-4e66-ac02-d75505a92469">
