### PR TITLE
chore: 🤖 Add Help subcommand for ipfs subcommands

### DIFF
--- a/src/commands/ipfs/index.ts
+++ b/src/commands/ipfs/index.ts
@@ -7,13 +7,15 @@ export default (program: Command) => {
   const cmd = program
     .command('ipfs')
     .option('-h, --help', t('printHelp'))
-    .description(t('ipfsDescription'));
+    .description(t('ipfsDescription'))
+    .addHelpCommand();
 
   cmd
     .command('add')
     .description(t('ipfsAddDescription'))
     .argument('<path>', t('ipfsAddPathDescription'))
-    .action((path: string) => addActionHandler({ path }));
+    .action((path: string) => addActionHandler({ path }))
+    .addHelpCommand();
 
   cmd
     .command('help')


### PR DESCRIPTION
## Why?

The IPFS subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1515](https://linear.app/fleekxyz/issue/PLAT-1515/add-help-to-ipfs-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

<img width="810" alt="Screenshot 2024-09-19 at 16 53 23" src="https://github.com/user-attachments/assets/ae07bc9f-aa75-4f76-818e-3e03ef09bcf2">

