### PR TITLE
chore: 🤖 Add Help subcommand for ipns subcommands

### DIFF
--- a/src/commands/ipns/index.ts
+++ b/src/commands/ipns/index.ts
@@ -11,7 +11,8 @@ export default (program: Command) => {
   const cmd = program
     .command('ipns')
     .option('-h, --help', 'Print help')
-    .description(t('ipnsDescription'));
+    .description(t('ipnsDescription'))
+    .addHelpCommand();
 
   cmd
     .command('create')
@@ -32,7 +33,8 @@ export default (program: Command) => {
     )
     .action((options: { siteId?: string; siteSlug?: string }) =>
       createActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('publish')
@@ -41,12 +43,14 @@ export default (program: Command) => {
     .option('--hash <string>', t('ipnsPublishOptionHashDesc'))
     .action((options: { name: string; hash: string }) =>
       publishActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('list')
     .description(t('ipnsListDescription'))
-    .action(() => listActionHandler());
+    .action(() => listActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('delete')
@@ -59,13 +63,15 @@ export default (program: Command) => {
         action: t('delete'),
       }),
     )
-    .action((options: { name: string }) => deleteActionHandler(options));
+    .action((options: { name: string }) => deleteActionHandler(options))
+    .addHelpCommand();
 
   cmd
     .command('resolve')
     .description(t('ipnsResolveDescription'))
     .argument('<name>', t('ipnsResolveArgName'))
-    .action((name: string) => resolveActionHandler({ name }));
+    .action((name: string) => resolveActionHandler({ name }))
+    .addHelpCommand();
 
   cmd
     .command('help')


### PR DESCRIPTION
## Why?

The IPNS subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1516](https://linear.app/fleekxyz/issue/PLAT-1516/add-help-to-ipns-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

<img width="812" alt="Screenshot 2024-09-19 at 16 56 12" src="https://github.com/user-attachments/assets/95352bb7-8293-49ba-ac8f-abbb2cc1c94f">


