### PR TITLE
chore: 🤖 Add Help subcommand for pat subcommands #42

### DIFF
--- a/src/commands/pat/index.ts
+++ b/src/commands/pat/index.ts
@@ -16,7 +16,8 @@ export default (program: Command) => {
   cmd
     .command('list') //
     .description(t('patListDesc'))
-    .action(listPersonalAccessTokensActionHandler);
+    .action(listPersonalAccessTokensActionHandler)
+    .addHelpCommand();
 
   cmd
     .command('create')
@@ -35,7 +36,8 @@ export default (program: Command) => {
         authApiUrl,
         ...args,
       });
-    });
+    })
+    .addHelpCommand();
 
   cmd
     .command('delete')
@@ -50,7 +52,8 @@ export default (program: Command) => {
     )
     .action((personalAccessTokenId: string) =>
       deletePersonalAccessTokenActionHandler({ personalAccessTokenId }),
-    );
+    )
+    .addHelpCommand();
 
   cmd.command('help').description(t('printHelp'));
 };


### PR DESCRIPTION
## Why?

The PAT subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1517](https://linear.app/fleekxyz/issue/PLAT-1517/add-help-to-pat-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

<img width="799" alt="Screenshot 2024-09-19 at 16 58 10" src="https://github.com/user-attachments/assets/61738c3a-38be-4160-ade8-5e294fc10dde">

