### PR TITLE
chore: 🤖 Add Help subcommand for projects subcommands #42

### DIFF
--- a/src/commands/projects/index.ts
+++ b/src/commands/projects/index.ts
@@ -9,22 +9,26 @@ export default (program: Command) => {
   const cmd = program
     .command('projects')
     .option('-h, --help', t('printHelp'))
-    .description(t('projectsDescription'));
+    .description(t('projectsDescription'))
+    .addHelpCommand();
 
   cmd
     .command('list')
     .description(t('projectsListDesc'))
-    .action(() => listProjectsActionHandler());
+    .action(() => listProjectsActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('switch')
     .option('--id <string>', t('projectsSwitchOptId'))
     .description(t('projectsSwitchBetween'))
-    .action((options: { id?: string }) => switchProjectActionHandler(options));
+    .action((options: { id?: string }) => switchProjectActionHandler(options))
+    .addHelpCommand();
 
   cmd
     .command('create')
     .option('--name <string>', t('projectsWhatNameOfProject'))
     .description(t('projectsCreateNewDesc'))
-    .action((options: { name: string }) => createProjectActionHandler(options));
+    .action((options: { name: string }) => createProjectActionHandler(options))
+    .addHelpCommand();
 };


### PR DESCRIPTION
## Why?

The Projects subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1518](https://linear.app/fleekxyz/issue/PLAT-1518/add-help-to-projects-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> create

<img width="785" alt="Screenshot 2024-09-19 at 17 01 25" src="https://github.com/user-attachments/assets/aefd4db2-7dac-4199-98d4-2769007145c2">

> switch

<img width="785" alt="Screenshot 2024-09-19 at 17 01 37" src="https://github.com/user-attachments/assets/d76aa319-be0c-4e90-9eda-a51bfbbc9753">
