### PR TITLE
chore: 🤖 Add Help subcommand for sites subcommands

### DIFF
--- a/src/commands/sites/index.ts
+++ b/src/commands/sites/index.ts
@@ -16,7 +16,8 @@ export default (program: Command) => {
   cmd
     .command('init')
     .description(t('sitesInitDescription'))
-    .action(() => initActionHandler());
+    .action(() => initActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('ci')
@@ -28,7 +29,8 @@ export default (program: Command) => {
         predefinedConfigPath: options.config,
         provider: options.provider,
       }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('deploy')
@@ -36,12 +38,14 @@ export default (program: Command) => {
     .option('-c, --config <fleekConfigPath>', t('deploySpecifyPathJson'))
     .action((options: { config?: string }) =>
       deployActionHandler({ predefinedConfigPath: options.config }),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('list')
     .description(t('listSitesDesc'))
-    .action(() => listActionHandler());
+    .action(() => listActionHandler())
+    .addHelpCommand();
 
   cmd
     .command('deployments')
@@ -56,7 +60,8 @@ export default (program: Command) => {
     .description(t('deploymentsListForSelectedSite'))
     .action((options: { id?: string; slug?: string }) =>
       listDeploymentsActionHandler(options),
-    );
+    )
+    .addHelpCommand();
 
   cmd
     .command('help')


### PR DESCRIPTION
## Why?

The Sites subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1519](https://linear.app/fleekxyz/issue/PLAT-1519/add-help-to-sites-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

> deploy

<img width="814" alt="Screenshot 2024-09-19 at 17 04 36" src="https://github.com/user-attachments/assets/a2289a30-9333-4cda-825e-02cf5dc7ea1e">


>  deployments

<img width="792" alt="Screenshot 2024-09-19 at 17 04 57" src="https://github.com/user-attachments/assets/836c8d17-2029-46b6-9cc8-644ec9e73d87">
