### PR TITLE
chore: 🤖 Add Help subcommand for storage subcommands

### DIFF
--- a/src/commands/storage/index.ts
+++ b/src/commands/storage/index.ts
@@ -15,7 +15,8 @@ export default (program: Command) => {
   cmd
     .command('list')
     .description(t('storageListDescription'))
-    .action(() => listStorageActionHandler());
+    .action(() => listStorageActionHandler())
+    .addHelpCommand();
 
   const getStorage = cmd
     .command('get')
@@ -24,7 +25,8 @@ export default (program: Command) => {
     .option(
       '-n, --name <filenameWithExtension>',
       t('storageNameOption', { action: t('get') }),
-    );
+    )
+    .addHelpCommand();
 
   getStorage.action((options: { cid?: string; name?: string }) => {
     if ((!options.name && !options.cid) || (options.name && options.cid)) {
@@ -51,7 +53,8 @@ export default (program: Command) => {
     .option(
       '-n, --name <filenameWithExtension>',
       t('storageNameOption', { action: t('delete') }),
-    );
+    )
+    .addHelpCommand();
 
   deleteStorage.action((options: { cid?: string; name?: string }) => {
     if ((!options.name && !options.cid) || (options.name && options.cid)) {
@@ -75,5 +78,6 @@ export default (program: Command) => {
     .command('add')
     .description(t('storageAddDescription'))
     .argument('<path>', t('ipfsAddPathDescription'))
-    .action((path: string) => addStorageActionHandler({ path }));
+    .action((path: string) => addStorageActionHandler({ path }))
+    .addHelpCommand();
 };


### PR DESCRIPTION
## Why?

The Storage subcommands should display detailed information to utilize any flags and options.

## How?

-  Declare each subcommand to include the help command

## Tickets?

- [PLAT-1520](https://linear.app/fleekxyz/issue/PLAT-1520/add-help-to-storage-subcommand)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

