### PR TITLE
feat: Add FLEEK_URL env var to functions

### DIFF
--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import { isValidFolder } from '@fleek-platform/utils-validation';
 import cliProgress from 'cli-progress';
 
 import { output } from '../../cli';
@@ -28,10 +27,7 @@ type DeployActionArgs = {
   assetsPath?: string;
 };
 
-const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
-  sdk,
-  args,
-}) => {
+const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args }) => {
   const env = getEnvironmentVariables({ env: args.env, envFile: args.envFile });
   const functionToDeploy = await getFunctionOrPrompt({ name: args.name, sdk });
   const filePath = await getFunctionPathOrPrompt({ path: args.filePath });
@@ -62,12 +58,17 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
     functionName: functionToDeploy.name,
   });
 
+  const updatedEnv = {
+    FLEEK_URL: functionToDeploy.invokeUrl,
+    ...env,
+  };
+
   const filePathToUpload = isSGX
     ? await getWasmCodeFromPath({ filePath })
     : await getJsCodeFromPath({
         filePath,
         bundle,
-        env,
+        env: updatedEnv,
         assetsCid,
       });
 
@@ -77,7 +78,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
     {
       format: t('uploadProgress', { action: t('uploadCodeToIpfs') }),
     },
-    cliProgress.Presets.shades_grey,
+    cliProgress.Presets.shades_grey
   );
 
   const uploadResult = await getUploadResult({
@@ -97,7 +98,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
         action: 'deploy',
         tryAgain: t('tryAgain'),
         message: t('uploadToIpfsFailed'),
-      }),
+      })
     );
 
     return;
@@ -123,7 +124,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
         action: 'deploy',
         tryAgain: t('tryAgain'),
         message: t('uploadToIpfsFailed'),
-      }),
+      })
     );
 
     return;
@@ -177,9 +178,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
     output.spinner(t('networkFetchMappings'));
     try {
       // TODO: The `fleek-test` address should be an env var
-      await fetch(
-        `https://fleek-test.network/services/0/ipfs/${uploadResult.pin.cid}`,
-      );
+      await fetch(`https://fleek-test.network/services/0/ipfs/${uploadResult.pin.cid}`);
     } catch {
       output.error(t('networkFetchFailed'));
       return;
@@ -197,20 +196,16 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
     output.printNewLine();
     output.log(`Blake3 Hash: ${blake3Hash} `);
     output.log(
-      `Invoke by sending request to https://fleek-test.network/services/3 with payload of {hash: <Blake3Hash>, decrypt: true, inputs: "foo"}`,
+      `Invoke by sending request to https://fleek-test.network/services/3 with payload of {hash: <Blake3Hash>, decrypt: true, inputs: "foo"}`
     );
     output.printNewLine();
     output.hint(`Here's an example:`);
-    output.link(
-      `curl ${functionToDeploy.invokeUrl} --data '{"hash": "${blake3Hash}", "decrypt": true, "input": "foo"}'`,
-    );
+    output.link(`curl ${functionToDeploy.invokeUrl} --data '{"hash": "${blake3Hash}", "decrypt": true, "input": "foo"}'`);
   }
 
   if (isUntrustedPublicEnvironment) {
     output.log(t('callFleekFunctionByNetworkUrlReq'));
-    output.link(
-      `https://fleek-test.network/services/1/ipfs/${uploadResult.pin.cid}`,
-    );
+    output.link(`https://fleek-test.network/services/1/ipfs/${uploadResult.pin.cid}`);
   }
 };
 

--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -27,7 +27,10 @@ type DeployActionArgs = {
   assetsPath?: string;
 };
 
-const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args }) => {
+const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
+  sdk,
+  args,
+}) => {
   const env = getEnvironmentVariables({ env: args.env, envFile: args.envFile });
   const functionToDeploy = await getFunctionOrPrompt({ name: args.name, sdk });
   const filePath = await getFunctionPathOrPrompt({ path: args.filePath });
@@ -78,7 +81,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
     {
       format: t('uploadProgress', { action: t('uploadCodeToIpfs') }),
     },
-    cliProgress.Presets.shades_grey
+    cliProgress.Presets.shades_grey,
   );
 
   const uploadResult = await getUploadResult({
@@ -98,7 +101,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
         action: 'deploy',
         tryAgain: t('tryAgain'),
         message: t('uploadToIpfsFailed'),
-      })
+      }),
     );
 
     return;
@@ -124,7 +127,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
         action: 'deploy',
         tryAgain: t('tryAgain'),
         message: t('uploadToIpfsFailed'),
-      })
+      }),
     );
 
     return;
@@ -178,7 +181,9 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
     output.spinner(t('networkFetchMappings'));
     try {
       // TODO: The `fleek-test` address should be an env var
-      await fetch(`https://fleek-test.network/services/0/ipfs/${uploadResult.pin.cid}`);
+      await fetch(
+        `https://fleek-test.network/services/0/ipfs/${uploadResult.pin.cid}`,
+      );
     } catch {
       output.error(t('networkFetchFailed'));
       return;
@@ -196,16 +201,20 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({ sdk, args })
     output.printNewLine();
     output.log(`Blake3 Hash: ${blake3Hash} `);
     output.log(
-      `Invoke by sending request to https://fleek-test.network/services/3 with payload of {hash: <Blake3Hash>, decrypt: true, inputs: "foo"}`
+      `Invoke by sending request to https://fleek-test.network/services/3 with payload of {hash: <Blake3Hash>, decrypt: true, inputs: "foo"}`,
     );
     output.printNewLine();
     output.hint(`Here's an example:`);
-    output.link(`curl ${functionToDeploy.invokeUrl} --data '{"hash": "${blake3Hash}", "decrypt": true, "input": "foo"}'`);
+    output.link(
+      `curl ${functionToDeploy.invokeUrl} --data '{"hash": "${blake3Hash}", "decrypt": true, "input": "foo"}'`,
+    );
   }
 
   if (isUntrustedPublicEnvironment) {
     output.log(t('callFleekFunctionByNetworkUrlReq'));
-    output.link(`https://fleek-test.network/services/1/ipfs/${uploadResult.pin.cid}`);
+    output.link(
+      `https://fleek-test.network/services/1/ipfs/${uploadResult.pin.cid}`,
+    );
   }
 };
 


### PR DESCRIPTION
## Why?

Include FLEEK_URL env var so users can call their own function / api.

## How?

- Pass the function invoke url as an env var.
- Can be overwritten by users (on purpose)

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
