### PR TITLE
fix: 🐛 Sites save configuration path resolution

### DIFF
--- a/src/utils/configuration/saveConfiguration.ts
+++ b/src/utils/configuration/saveConfiguration.ts
@@ -22,15 +22,22 @@ export type SaveConfigurationArgs = {
 
 type ConfigFilePath = string;
 
+const DEV_SRC_UTILS_PATH = '/src/utils';
+const basePath = path.dirname(__filename).includes(DEV_SRC_UTILS_PATH)
+? '../..'
+: '';
+
 const filePathForTypescriptConfig = path.resolve(
   path.dirname(__filename),
-  '../../templates/sites/config',
+  basePath,
+  'templates/sites/config',
   getConfigTemplateByTypeName('Typescript'),
 );
 
 const filePathForJavascriptConfig = path.resolve(
   path.dirname(__filename),
-  '../../templates/sites/config',
+  basePath,
+  'templates/sites/config',
   getConfigTemplateByTypeName('Javascript'),
 );
 

--- a/src/utils/configuration/saveConfiguration.ts
+++ b/src/utils/configuration/saveConfiguration.ts
@@ -24,8 +24,8 @@ type ConfigFilePath = string;
 
 const DEV_SRC_UTILS_PATH = '/src/utils';
 const basePath = path.dirname(__filename).includes(DEV_SRC_UTILS_PATH)
-? '../..'
-: '';
+  ? '../..'
+  : '';
 
 const filePathForTypescriptConfig = path.resolve(
   path.dirname(__filename),


### PR DESCRIPTION
## Why?

Save configuration revision

## How?

- Fix configuration template path

## Tickets?

- [PLAT-1728](https://linear.app/fleekxyz/issue/PLAT-1728/save-configuration-paths-for-js-and-ts)
- 

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
