### PR TITLE
fix: 🐛 Hide deprecation errors on Global install execution

### DIFF
--- a/.changeset/smart-spies-invent.md
+++ b/.changeset/smart-spies-invent.md
@@ -1,0 +1,5 @@
+---
+'@fleek-platform/cli': patch
+---
+
+Hide deprecation warnings on global install

--- a/bin/index.js
+++ b/bin/index.js
@@ -12,10 +12,18 @@ const semver = require('semver');
 const { asyncParser, init } = require('../dist/bundle');
 const { loadJSONFromPackageRoot } = require('../dist/utils/json');
 const { checkForPackageUpdates } = require('../dist/utils/update-notifier');
+const { isGlobalNodeModuleInstall } = require('../dist/utils/fs');
 
 const pkgJson = loadJSONFromPackageRoot('package.json');
 const pkgVersion = pkgJson.version;
 const requiredVersion = pkgJson.engines.node;
+
+// Hide deprecation warnings for production builds
+// Otherwise, shows in development environment
+// https://nodejs.org/api/process.html#processnodeprecation
+if (isGlobalNodeModuleInstall()) {
+  process.noDeprecation = true;
+}
 
 if (!semver.satisfies(process.version, requiredVersion)) {
   // TODO: Pick text from locales

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -20,7 +20,8 @@ export const fileExists = async (path: string) => {
 };
 
 export const isGlobalNodeModuleInstall = () => {
-  const GLOBAL_EXEC_PATH_INCLUDES = 'node_modules/@fleek-platform/cli/bin/index.js';
+  const GLOBAL_EXEC_PATH_INCLUDES =
+    'node_modules/@fleek-platform/cli/bin/index.js';
   const executedScript = realpathSync(process.argv[1]);
   return executedScript.includes(GLOBAL_EXEC_PATH_INCLUDES);
-}
+};

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,4 +1,4 @@
-import { promises as fsPromises } from 'node:fs';
+import { promises as fsPromises, realpathSync } from 'node:fs';
 
 interface FsError extends Error {
   code?: string;
@@ -18,3 +18,9 @@ export const fileExists = async (path: string) => {
     throw e;
   }
 };
+
+export const isGlobalNodeModuleInstall = () => {
+  const GLOBAL_EXEC_PATH_INCLUDES = 'node_modules/@fleek-platform/cli/bin/index.js';
+  const executedScript = realpathSync(process.argv[1]);
+  return executedScript.includes(GLOBAL_EXEC_PATH_INCLUDES);
+}


### PR DESCRIPTION
## Why?

Hide deprecation errors on Global install execution.

## How?

- Create global install checker
- Hide deprecation warnings on production/global-install

## Tickets?

- [PLAT-1720](https://linear.app/fleekxyz/issue/PLAT-1720/[cli][functions]-punycode-deprecation-warning-is-displayed-when-using)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

<img width="606" alt="Screenshot 2024-11-05 at 14 22 37" src="https://github.com/user-attachments/assets/ed4b0ecb-826c-467e-b988-6fd2183a54ca">
