### PR TITLE
chore: 🤖 Extend none zero exit for sites deploy failures

### DIFF
--- a/.changeset/two-nails-knock.md
+++ b/.changeset/two-nails-knock.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/cli": minor
+---
+
+Extend none zero exit for sites deploy failures

--- a/src/commands/sites/deploy.ts
+++ b/src/commands/sites/deploy.ts
@@ -43,8 +43,7 @@ const deployAction: SdkGuardedFunction<DeployActionArgs> = async ({
   if (!root) {
     output.error(t('somethingWrongDurUpload'));
     output.printNewLine();
-
-    return;
+    process.exit(1);
   }
 
   output.spinner(t('startingSiteDeployment'));

--- a/src/commands/sites/utils/waitUntilDeploymentFinishedAndInformUser.ts
+++ b/src/commands/sites/utils/waitUntilDeploymentFinishedAndInformUser.ts
@@ -50,8 +50,7 @@ export const waitUntilDeploymentFinishedAndInformUser = async ({
   if (deploymentStatus === 'RELEASE_FAILED') {
     output.error(t('deployNotFinishTryAgain'));
     output.printNewLine();
-
-    return;
+    process.exit(1);
   }
 
   output.success(`${t('deployed')}!`);


### PR DESCRIPTION
## Why?

Extend none zero exit for sites deploy failures

## How?

N/A

## Tickets?

- [PLAT-1738](https://linear.app/fleekxyz/issue/PLAT-1738/on-deployment-failure-return-non-zero)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
