### PR TITLE
fix: 🐛 Downgrade 'undici' to v6 to support Node.js v18

### DIFF
--- a/.changeset/modern-clocks-kick.md
+++ b/.changeset/modern-clocks-kick.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/cli": patch
+---
+
+fix: 🐛 Downgrade 'undici' to v6 to support Node.js v18

--- a/.changeset/pink-gifts-perform.md
+++ b/.changeset/pink-gifts-perform.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/cli": patch
+---
+
+Add "undici" package to support "yarn"

--- a/.changeset/pink-gifts-perform.md
+++ b/.changeset/pink-gifts-perform.md
@@ -1,5 +1,0 @@
----
-"@fleek-platform/cli": patch
----
-
-Add "undici" package to support "yarn"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "prompts": "^2.4.2",
     "semver": "^7.3.8",
     "ts-node": "10.9.1",
+    "undici": "^7.1.0",
     "unique-names-generator": "^4.7.1",
     "update-notifier-cjs": "^5.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prompts": "^2.4.2",
     "semver": "^7.3.8",
     "ts-node": "10.9.1",
-    "undici": "^7.1.0",
+    "undici": "^6.21.0",
     "unique-names-generator": "^4.7.1",
     "update-notifier-cjs": "^5.1.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ specifiers:
   semver: ^7.3.8
   ts-node: 10.9.1
   typescript: 4.9.3
-  undici: ^7.1.0
+  undici: ^6.21.0
   unique-names-generator: ^4.7.1
   update-notifier-cjs: ^5.1.6
   vitest: 1.3.1
@@ -84,13 +84,13 @@ dependencies:
   lodash-es: 4.17.21
   multiformats: 9.9.0
   nanoid: 3.3.7
-  native-fetch: 4.0.2_undici@7.1.0
+  native-fetch: 4.0.2_undici@6.21.0
   ora: 3.4.0
   press-any-key: 0.1.1
   prompts: 2.4.2
   semver: 7.6.3
   ts-node: 10.9.1_typescript@4.9.3
-  undici: 7.1.0
+  undici: 6.21.0
   unique-names-generator: 4.7.1
   update-notifier-cjs: 5.1.6
 
@@ -5175,12 +5175,12 @@ packages:
     resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
     dev: true
 
-  /native-fetch/4.0.2_undici@7.1.0:
+  /native-fetch/4.0.2_undici@6.21.0:
     resolution: {integrity: sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==}
     peerDependencies:
       undici: '*'
     dependencies:
-      undici: 7.1.0
+      undici: 6.21.0
     dev: false
 
   /negotiator/0.6.3:
@@ -6483,9 +6483,9 @@ packages:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
     dev: true
 
-  /undici/7.1.0:
-    resolution: {integrity: sha512-3+mdX2R31khuLCm2mKExSlMdJsfol7bJkIMH80tdXA74W34rT1jKemUTlYR7WY3TqsV4wfOgpatWmmB2Jl1+5g==}
-    engines: {node: '>=20.18.1'}
+  /undici/6.21.0:
+    resolution: {integrity: sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==}
+    engines: {node: '>=18.17'}
     dev: false
 
   /unique-names-generator/4.7.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ specifiers:
   semver: ^7.3.8
   ts-node: 10.9.1
   typescript: 4.9.3
+  undici: ^7.1.0
   unique-names-generator: ^4.7.1
   update-notifier-cjs: ^5.1.6
   vitest: 1.3.1
@@ -83,12 +84,13 @@ dependencies:
   lodash-es: 4.17.21
   multiformats: 9.9.0
   nanoid: 3.3.7
-  native-fetch: 4.0.2
+  native-fetch: 4.0.2_undici@7.1.0
   ora: 3.4.0
   press-any-key: 0.1.1
   prompts: 2.4.2
   semver: 7.6.3
   ts-node: 10.9.1_typescript@4.9.3
+  undici: 7.1.0
   unique-names-generator: 4.7.1
   update-notifier-cjs: 5.1.6
 
@@ -5173,10 +5175,12 @@ packages:
     resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
     dev: true
 
-  /native-fetch/4.0.2:
+  /native-fetch/4.0.2_undici@7.1.0:
     resolution: {integrity: sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==}
     peerDependencies:
       undici: '*'
+    dependencies:
+      undici: 7.1.0
     dev: false
 
   /negotiator/0.6.3:
@@ -6478,6 +6482,11 @@ packages:
   /undici-types/6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
     dev: true
+
+  /undici/7.1.0:
+    resolution: {integrity: sha512-3+mdX2R31khuLCm2mKExSlMdJsfol7bJkIMH80tdXA74W34rT1jKemUTlYR7WY3TqsV4wfOgpatWmmB2Jl1+5g==}
+    engines: {node: '>=20.18.1'}
+    dev: false
 
   /unique-names-generator/4.7.1:
     resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}


### PR DESCRIPTION
## Why?

- Downgraded 'undici' to v6 to support Node.js v18


## Tickets?

- [PLAT-1900](https://linear.app/fleekxyz/issue/PLAT-1900/yarn-global-installation-of-fleek-platformcli-fails-site-deployment)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] You have manually tested
- [ ] You have provided tests
